### PR TITLE
Upgrade documentation and aws cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Install Openshift 4.5.7 on AWS (Internal Red Hat)
+# Install Openshift 4.6.11 on AWS (Internal Red Hat)
 OpenShift 4 AWS Installation IPI at OpenTLC 
 
 ### Prerequisite
@@ -20,7 +20,7 @@ OpenShift 4 AWS Installation IPI at OpenTLC
 export AWSKEY={AWSKEY generated from opentlc}
 export AWSSECRETKEY={AWSSECRETKEY generated from opentlc}
 export REGION=ap-southeast-1
-export OCP_VERSION=4.5.7
+export OCP_VERSION=4.6.11
 export GUID={GUID generated from opentlc}
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Install Openshift 4.4.4 on AWS (Internal Red Hat)
+# Install Openshift 4.5.7 on AWS (Internal Red Hat)
 OpenShift 4 AWS Installation IPI at OpenTLC 
 
 ### Prerequisite
@@ -20,7 +20,7 @@ OpenShift 4 AWS Installation IPI at OpenTLC
 export AWSKEY={AWSKEY generated from opentlc}
 export AWSSECRETKEY={AWSSECRETKEY generated from opentlc}
 export REGION=ap-southeast-1
-export OCP_VERSION=4.5.6
+export OCP_VERSION=4.5.7
 export GUID={GUID generated from opentlc}
 ```
 

--- a/prepare-openshift-installer.sh
+++ b/prepare-openshift-installer.sh
@@ -4,25 +4,25 @@
 export AWSKEY=
 export AWSSECRETKEY=
 export REGION=ap-southeast-1
-export OCP_VERSION=4.5.7
+export OCP_VERSION=4.6.11
 export GUID=
 
 set -xe
 
 # Download and extract the latest AWS Command Line Interface
-curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscli-bundle.zip"
 
 # Extract downloaded AWS Command Line Interface archive file
 unzip ./awscli-bundle.zip
 
 # Install the AWS CLI into /bin/aws
-./awscli-bundle/install -i /usr/local/aws -b /bin/aws
+./aws/install -i /usr/local/aws-cli -b /usr/local/bin
 
 # Validate that the AWS CLI works
 aws --version
 
 # Cleanup downloaded files
-rm -rf ./awscli-bundle ./awscli-bundle.zip
+rm -rf ./aws ./awscli-bundle.zip
 
 # Configure AWS credentials
 mkdir $HOME/.aws

--- a/prepare-openshift-installer.sh
+++ b/prepare-openshift-installer.sh
@@ -4,7 +4,7 @@
 export AWSKEY=
 export AWSSECRETKEY=
 export REGION=ap-southeast-1
-export OCP_VERSION=4.5.6
+export OCP_VERSION=4.5.7
 export GUID=
 
 set -xe


### PR DESCRIPTION
Upgrade AWS cli to v2, since I got warning when use v1. Old version will not be supported after July 2021. 